### PR TITLE
build: fix nanoarrow download url pattern in thirdparty toolchain

### DIFF
--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -48,6 +48,21 @@ else()
   set(ARROW_SOURCE_URL
       "https://www.apache.org/dyn/closer.lua?action=download&filename=/arrow/arrow-${ICEBERG_ARROW_BUILD_VERSION}/apache-arrow-${ICEBERG_ARROW_BUILD_VERSION}.tar.gz"
       "https://downloads.apache.org/arrow/arrow-${ICEBERG_ARROW_BUILD_VERSION}/apache-arrow-${ICEBERG_ARROW_BUILD_VERSION}.tar.gz"
+      "https://archive.apache.org/dist/arrow/arrow-${ICEBERG_ARROW_BUILD_VERSION}/apache-arrow-${ICEBERG_ARROW_BUILD_VERSION}.tar.gz"
+  )
+endif()
+
+set(ICEBERG_NANOARROW_BUILD_VERSION "0.8.0")
+set(ICEBERG_NANOARROW_BUILD_SHA256_CHECKSUM
+    "6e61e2819c9138e9092ba32b568ed6f4594928b306171937251eaaafa7dc2b8c")
+
+if(DEFINED ENV{ICEBERG_NANOARROW_URL})
+  set(NANOARROW_SOURCE_URL "$ENV{ICEBERG_NANOARROW_URL}")
+else()
+  set(NANOARROW_SOURCE_URL
+      "https://www.apache.org/dyn/closer.lua?action=download&filename=/arrow/apache-arrow-nanoarrow-${ICEBERG_NANOARROW_BUILD_VERSION}/apache-arrow-nanoarrow-${ICEBERG_NANOARROW_BUILD_VERSION}.tar.gz"
+      "https://downloads.apache.org/arrow/apache-arrow-nanoarrow-${ICEBERG_NANOARROW_BUILD_VERSION}/apache-arrow-nanoarrow-${ICEBERG_NANOARROW_BUILD_VERSION}.tar.gz"
+      "https://archive.apache.org/dist/arrow/apache-arrow-nanoarrow-${ICEBERG_NANOARROW_BUILD_VERSION}/apache-arrow-nanoarrow-${ICEBERG_NANOARROW_BUILD_VERSION}.tar.gz"
   )
 endif()
 
@@ -256,17 +271,10 @@ endfunction()
 function(resolve_nanoarrow_dependency)
   prepare_fetchcontent()
 
-  if(DEFINED ENV{ICEBERG_NANOARROW_URL})
-    set(NANOARROW_URL "$ENV{ICEBERG_NANOARROW_URL}")
-  else()
-    set(NANOARROW_URL
-        "https://dlcdn.apache.org/arrow/apache-arrow-nanoarrow-0.8.0/apache-arrow-nanoarrow-0.8.0.tar.gz"
-    )
-  endif()
-
   fetchcontent_declare(nanoarrow
                        ${FC_DECLARE_COMMON_OPTIONS}
-                       URL ${NANOARROW_URL}
+                       URL ${NANOARROW_SOURCE_URL}
+                       URL_HASH "SHA256=${ICEBERG_NANOARROW_BUILD_SHA256_CHECKSUM}"
                            FIND_PACKAGE_ARGS
                            NAMES
                            nanoarrow

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -275,10 +275,10 @@ function(resolve_nanoarrow_dependency)
                        ${FC_DECLARE_COMMON_OPTIONS}
                        URL ${NANOARROW_SOURCE_URL}
                        URL_HASH "SHA256=${ICEBERG_NANOARROW_BUILD_SHA256_CHECKSUM}"
-                           FIND_PACKAGE_ARGS
-                           NAMES
-                           nanoarrow
-                           CONFIG)
+                       FIND_PACKAGE_ARGS
+                       NAMES
+                       nanoarrow
+                       CONFIG)
   fetchcontent_makeavailable(nanoarrow)
 
   if(nanoarrow_SOURCE_DIR)


### PR DESCRIPTION
The user requested to fix the download URL for `nanoarrow` in `cmake_modules/IcebergThirdpartyToolchain.cmake` so it doesn't break CI when a new version is released and the old version is deleted from the primary mirror.

This was resolved by applying the same robust URL fallback pattern used for the Arrow dependency. The variables `ICEBERG_NANOARROW_BUILD_VERSION`, `ICEBERG_NANOARROW_BUILD_SHA256_CHECKSUM`, and `NANOARROW_SOURCE_URL` are now defined and include multiple mirrors, specifically adding the `archive.apache.org` fallback. The `ARROW_SOURCE_URL` was also enhanced to include its corresponding archive URL for additional stability.

---
*PR created automatically by Jules for task [1271380168126250009](https://jules.google.com/task/1271380168126250009) started by @wgtmac*