### PR TITLE
Parse JWT exp claim from token to set expires_at_millis_

### DIFF
--- a/src/iceberg/catalog/rest/auth/auth_properties.cc
+++ b/src/iceberg/catalog/rest/auth/auth_properties.cc
@@ -21,7 +21,11 @@
 
 #include <utility>
 
+#include <nlohmann/json.hpp>
+
 #include "iceberg/catalog/rest/catalog_properties.h"
+#include "iceberg/util/macros.h"
+#include "iceberg/util/transform_util.h"
 
 namespace iceberg::rest::auth {
 
@@ -75,7 +79,25 @@ Result<AuthProperties> AuthProperties::FromProperties(
     }
   }
 
-  // TODO(lishuxu): Parse JWT exp claim from token to set expires_at_millis_.
+  // Parse JWT exp claim from token to set expires_at_millis_.
+  if (auto token = config.token(); !token.empty()) {
+    auto first_dot = token.find('.');
+    auto last_dot = token.find('.', first_dot + 1);
+    if (first_dot != std::string::npos && last_dot != std::string::npos) {
+      auto payload_encoded = token.substr(first_dot + 1, last_dot - first_dot - 1);
+      auto payload_decoded = TransformUtil::Base64UrlDecode(payload_encoded);
+      if (payload_decoded.has_value()) {
+        try {
+          auto payload_json = nlohmann::json::parse(payload_decoded.value());
+          if (payload_json.contains("exp") && payload_json["exp"].is_number()) {
+            config.expires_at_millis_ = payload_json["exp"].get<int64_t>() * 1000;
+          }
+        } catch (const nlohmann::json::parse_error& e) {
+          // Ignore parse errors from invalid JWT payloads.
+        }
+      }
+    }
+  }
 
   return config;
 }

--- a/src/iceberg/catalog/rest/auth/auth_properties.h
+++ b/src/iceberg/catalog/rest/auth/auth_properties.h
@@ -96,6 +96,9 @@ class ICEBERG_REST_EXPORT AuthProperties : public ConfigBase<AuthProperties> {
   /// \brief Build optional OAuth params (audience, resource) from config.
   std::unordered_map<std::string, std::string> optional_oauth_params() const;
 
+  /// \brief Get the token expiration time in milliseconds.
+  std::optional<int64_t> expires_at_millis() const { return expires_at_millis_; }
+
  private:
   std::string client_id_;
   std::string client_secret_;

--- a/src/iceberg/test/auth_manager_test.cc
+++ b/src/iceberg/test/auth_manager_test.cc
@@ -358,4 +358,29 @@ TEST_F(AuthManagerTest, OAuthTokenResponseNATokenType) {
   EXPECT_EQ(result->token_type, "N_A");
 }
 
+// Verifies that JWT exp claim is parsed from token in AuthProperties
+TEST_F(AuthManagerTest, AuthPropertiesParseJwtExp) {
+  // Payload: {"exp": 1735689600} (2025-01-01 00:00:00 UTC)
+  // Base64Url(payload): "eyJleHAiOiAxNzM1Njg5NjAwfQ"
+  std::string token = "header.eyJleHAiOiAxNzM1Njg5NjAwfQ.signature";
+  std::unordered_map<std::string, std::string> properties = {
+      {AuthProperties::kToken.key(), token}};
+
+  auto config_result = AuthProperties::FromProperties(properties);
+  ASSERT_THAT(config_result, IsOk());
+  ASSERT_TRUE(config_result->expires_at_millis().has_value());
+  EXPECT_EQ(config_result->expires_at_millis().value(), 1735689600000LL);
+}
+
+// Verifies that invalid JWT doesn't set expiration
+TEST_F(AuthManagerTest, AuthPropertiesInvalidJwtNoExp) {
+  std::string token = "invalid-token-no-dots";
+  std::unordered_map<std::string, std::string> properties = {
+      {AuthProperties::kToken.key(), token}};
+
+  auto config_result = AuthProperties::FromProperties(properties);
+  ASSERT_THAT(config_result, IsOk());
+  EXPECT_FALSE(config_result->expires_at_millis().has_value());
+}
+
 }  // namespace iceberg::rest::auth

--- a/src/iceberg/test/matchers.h
+++ b/src/iceberg/test/matchers.h
@@ -124,12 +124,14 @@ class HasValueMatcher {
 
   void DescribeTo(std::ostream* os) const {
     *os << "has a value that ";
-    matcher_.DescribeTo(os);
+    ::testing::internal::DescribeMatcher<const typename MatcherT::value_type&>(
+        matcher_, os);
   }
 
   void DescribeNegationTo(std::ostream* os) const {
     *os << "does not have a value that ";
-    matcher_.DescribeTo(os);
+    ::testing::internal::DescribeMatcher<const typename MatcherT::value_type&>(
+        matcher_, os);
   }
 
  private:
@@ -140,7 +142,9 @@ class HasValueMatcher {
 template <typename MatcherT>
 auto HasValue(MatcherT&& matcher) {
   return ::testing::MakePolymorphicMatcher(
-      HasValueMatcher<std::remove_cvref_t<MatcherT>>(std::forward<MatcherT>(matcher)));
+      HasValueMatcher<::testing::Matcher<const std::remove_cvref_t<MatcherT>&>>(
+          ::testing::SafeMatcherCast<const std::remove_cvref_t<MatcherT>&>(
+              std::forward<MatcherT>(matcher))));
 }
 
 // Overload for the common case where we just want to check for presence of any value

--- a/src/iceberg/test/transform_util_test.cc
+++ b/src/iceberg/test/transform_util_test.cc
@@ -161,30 +161,30 @@ TEST(TransformUtilTest, Base64Encode) {
 
 TEST(TransformUtilTest, Base64UrlDecode) {
   // Empty string
-  EXPECT_THAT(TransformUtil::Base64UrlDecode(""), IsOkAndEq(""));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode(""), HasValue(std::string("")));
 
   // No padding
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ"), IsOkAndEq("a"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("YWI"), IsOkAndEq("ab"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("YWJj"), IsOkAndEq("abc"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ"), HasValue(std::string("a")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YWI"), HasValue(std::string("ab")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YWJj"), HasValue(std::string("abc")));
 
   // RFC 4648 test vectors
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zg"), IsOkAndEq("f"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm8"), IsOkAndEq("fo"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9v"), IsOkAndEq("foo"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYg"), IsOkAndEq("foob"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmE"), IsOkAndEq("fooba"));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmFy"), IsOkAndEq("foobar"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zg"), HasValue(std::string("f")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm8"), HasValue(std::string("fo")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9v"), HasValue(std::string("foo")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYg"), HasValue(std::string("foob")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmE"), HasValue(std::string("fooba")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmFy"), HasValue(std::string("foobar")));
 
   // Base64Url specific characters
   // "-" -> 62, "_" -> 63
   // ">>?" -> Base64: "Pj4/" -> Base64Url: "Pj4_"
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Pj4_"), IsOkAndEq(">>?"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Pj4_"), HasValue(std::string(">>?")));
   // "?>>" -> Base64: "Pz4+" -> Base64Url: "Pz4-"
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Pz4-"), IsOkAndEq("?>>"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Pz4-"), HasValue(std::string("?>>")));
 
   // Padding should be handled if present (though JWT omits it)
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ=="), IsOkAndEq("a"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ=="), HasValue(std::string("a")));
 
   // Invalid characters
   EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ*"),

--- a/src/iceberg/test/transform_util_test.cc
+++ b/src/iceberg/test/transform_util_test.cc
@@ -159,6 +159,38 @@ TEST(TransformUtilTest, Base64Encode) {
   EXPECT_EQ("AA==", TransformUtil::Base64Encode({"\x00", 1}));
 }
 
+TEST(TransformUtilTest, Base64UrlDecode) {
+  // Empty string
+  EXPECT_THAT(TransformUtil::Base64UrlDecode(""), IsOkAndEq(""));
+
+  // No padding
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ"), IsOkAndEq("a"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YWI"), IsOkAndEq("ab"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YWJj"), IsOkAndEq("abc"));
+
+  // RFC 4648 test vectors
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zg"), IsOkAndEq("f"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm8"), IsOkAndEq("fo"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9v"), IsOkAndEq("foo"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYg"), IsOkAndEq("foob"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmE"), IsOkAndEq("fooba"));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmFy"), IsOkAndEq("foobar"));
+
+  // Base64Url specific characters
+  // "-" -> 62, "_" -> 63
+  // ">>?" -> Base64: "Pj4/" -> Base64Url: "Pj4_"
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Pj4_"), IsOkAndEq(">>?"));
+  // "?>>" -> Base64: "Pz4+" -> Base64Url: "Pz4-"
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Pz4-"), IsOkAndEq("?>>"));
+
+  // Padding should be handled if present (though JWT omits it)
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ=="), IsOkAndEq("a"));
+
+  // Invalid characters
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("YQ*"),
+              IsError(ErrorKind::kInvalidArgument));
+}
+
 struct ParseRoundTripParam {
   std::string name;
   std::string str;

--- a/src/iceberg/test/transform_util_test.cc
+++ b/src/iceberg/test/transform_util_test.cc
@@ -174,7 +174,8 @@ TEST(TransformUtilTest, Base64UrlDecode) {
   EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9v"), HasValue(std::string("foo")));
   EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYg"), HasValue(std::string("foob")));
   EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmE"), HasValue(std::string("fooba")));
-  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmFy"), HasValue(std::string("foobar")));
+  EXPECT_THAT(TransformUtil::Base64UrlDecode("Zm9vYmFy"),
+              HasValue(std::string("foobar")));
 
   // Base64Url specific characters
   // "-" -> 62, "_" -> 63

--- a/src/iceberg/util/transform_util.cc
+++ b/src/iceberg/util/transform_util.cc
@@ -283,4 +283,40 @@ std::string TransformUtil::Base64Encode(std::string_view str_to_encode) {
   return encoded;
 }
 
+Result<std::string> TransformUtil::Base64UrlDecode(std::string_view str_to_decode) {
+  std::string decoded;
+  decoded.reserve(str_to_decode.size() * 3 / 4);
+
+  uint32_t val = 0;
+  int32_t bits = 0;
+  for (char c : str_to_decode) {
+    if (c == '=') break;
+    int8_t v = -1;
+    if (c >= 'A' && c <= 'Z')
+      v = static_cast<int8_t>(c - 'A');
+    else if (c >= 'a' && c <= 'z')
+      v = static_cast<int8_t>(c - 'a' + 26);
+    else if (c >= '0' && c <= '9')
+      v = static_cast<int8_t>(c - '0' + 52);
+    else if (c == '-' || c == '+')
+      v = 62;
+    else if (c == '_' || c == '/')
+      v = 63;
+
+    if (v == -1) {
+      return InvalidArgument("Invalid character in Base64Url string: '{}'", c);
+    }
+
+    val = (val << 6) | static_cast<uint32_t>(v);
+    bits += 6;
+
+    if (bits >= 8) {
+      bits -= 8;
+      decoded.push_back(static_cast<char>((val >> bits) & 0xFF));
+      val &= (1U << bits) - 1;
+    }
+  }
+  return decoded;
+}
+
 }  // namespace iceberg

--- a/src/iceberg/util/transform_util.h
+++ b/src/iceberg/util/transform_util.h
@@ -139,6 +139,9 @@ class ICEBERG_EXPORT TransformUtil {
 
   /// \brief Base64 encode a string
   static std::string Base64Encode(std::string_view str_to_encode);
+
+  /// \brief Base64Url decode a string
+  static Result<std::string> Base64UrlDecode(std::string_view str_to_decode);
 };
 
 }  // namespace iceberg


### PR DESCRIPTION
This change implements parsing of the JWT `exp` (expiration) claim from the OAuth2 token in `AuthProperties`. 

Key changes:
1.  **TransformUtil**: Added `Base64UrlDecode` to handle RFC 4648 Base64Url encoding, which is used in JWT payloads. The implementation is robust against integer overflow and handles both standard and URL-safe Base64 characters.
2.  **AuthProperties**: 
    - Updated `FromProperties` to detect if a token is present.
    - If present and formatted as a JWT (three parts separated by dots), it decodes the payload part and extracts the `exp` claim.
    - The expiration time is converted from seconds to milliseconds and stored in `expires_at_millis_`.
    - Added a public getter `expires_at_millis()`.
3.  **Tests**:
    - Added tests for `Base64UrlDecode` with various test vectors, including edge cases and invalid characters.
    - Added tests in `AuthManagerTest` to verify that `AuthProperties` correctly parses the expiration time from a mock JWT token and handles invalid tokens gracefully.

---
*PR created automatically by Jules for task [409089801954026600](https://jules.google.com/task/409089801954026600) started by @wgtmac*