### PR TITLE
Refactor: Move commonly used constants to constants.h

### DIFF
--- a/src/iceberg/catalog/rest/json_serde.cc
+++ b/src/iceberg/catalog/rest/json_serde.cc
@@ -381,7 +381,7 @@ Result<CreateTableRequest> CreateTableRequestFromJson(const nlohmann::json& json
                             GetJsonValue<nlohmann::json>(json, kPartitionSpec));
     ICEBERG_ASSIGN_OR_RAISE(request.partition_spec,
                             PartitionSpecFromJson(request.schema, partition_spec,
-                                                  PartitionSpec::kInitialSpecId));
+                                                  kInitialSpecId));
   }
   if (json.contains(kWriteOrder)) {
     ICEBERG_ASSIGN_OR_RAISE(auto sort_order,

--- a/src/iceberg/catalog/rest/json_serde.cc
+++ b/src/iceberg/catalog/rest/json_serde.cc
@@ -379,9 +379,9 @@ Result<CreateTableRequest> CreateTableRequestFromJson(const nlohmann::json& json
   if (json.contains(kPartitionSpec)) {
     ICEBERG_ASSIGN_OR_RAISE(auto partition_spec,
                             GetJsonValue<nlohmann::json>(json, kPartitionSpec));
-    ICEBERG_ASSIGN_OR_RAISE(request.partition_spec,
-                            PartitionSpecFromJson(request.schema, partition_spec,
-                                                  kInitialSpecId));
+    ICEBERG_ASSIGN_OR_RAISE(
+        request.partition_spec,
+        PartitionSpecFromJson(request.schema, partition_spec, kInitialSpecId));
   }
   if (json.contains(kWriteOrder)) {
     ICEBERG_ASSIGN_OR_RAISE(auto sort_order,

--- a/src/iceberg/constants.h
+++ b/src/iceberg/constants.h
@@ -38,6 +38,19 @@ constexpr int64_t kInvalidSequenceNumber = -1;
 /// adapter.
 constexpr int64_t kUnassignedSequenceNumber = -1;
 
-// TODO(gangwu): move other commonly used constants here.
+constexpr int32_t kInitialSchemaId = 0;
+constexpr int32_t kInitialColumnId = 0;
+constexpr int32_t kInvalidColumnId = -1;
+
+constexpr int32_t kInvalidFieldId = -1;
+
+constexpr int32_t kInitialSpecId = 0;
+/// \brief The start ID for partition field.  It is only used to generate
+/// partition field id for v1 metadata where it is tracked.
+constexpr int32_t kLegacyPartitionDataIdStart = 1000;
+constexpr int32_t kInvalidPartitionFieldId = -1;
+
+constexpr int32_t kUnsortedOrderId = 0;
+constexpr int32_t kInitialSortOrderId = 1;
 
 }  // namespace iceberg

--- a/src/iceberg/json_serde.cc
+++ b/src/iceberg/json_serde.cc
@@ -564,7 +564,7 @@ Result<std::unique_ptr<Schema>> SchemaFromJson(const nlohmann::json& json) {
       auto identifier_field_ids,
       GetJsonValueOrDefault<std::vector<int32_t>>(json, kIdentifierFieldIds));
 
-  return Schema::Make(std::move(fields), schema_id_opt.value_or(Schema::kInitialSchemaId),
+  return Schema::Make(std::move(fields), schema_id_opt.value_or(kInitialSchemaId),
                       std::move(identifier_field_ids));
 }
 
@@ -600,7 +600,7 @@ Result<std::unique_ptr<PartitionField>> PartitionFieldFromJson(
   if (allow_field_id_missing) {
     // Partition field id in v1 is not tracked, so we use -1 to indicate that.
     ICEBERG_ASSIGN_OR_RAISE(field_id, GetJsonValueOrDefault<int32_t>(
-                                          json, kFieldId, SchemaField::kInvalidFieldId));
+                                          json, kFieldId, kInvalidFieldId));
   } else {
     ICEBERG_ASSIGN_OR_RAISE(field_id, GetJsonValue<int32_t>(json, kFieldId));
   }
@@ -1001,14 +1001,14 @@ Status ParsePartitionSpecs(const nlohmann::json& json, int8_t format_version,
                             SafeDumpJson(partition_spec_json));
     }
 
-    int32_t next_partition_field_id = PartitionSpec::kLegacyPartitionDataIdStart;
+    int32_t next_partition_field_id = kLegacyPartitionDataIdStart;
     std::vector<PartitionField> fields;
     for (const auto& entry_json : partition_spec_json) {
       ICEBERG_ASSIGN_OR_RAISE(
           auto field, PartitionFieldFromJson(
                           entry_json, /*allow_field_id_missing=*/format_version == 1));
       int32_t field_id = field->field_id();
-      if (field_id == SchemaField::kInvalidFieldId) {
+      if (field_id == kInvalidFieldId) {
         // If the field ID is not set, we need to assign a new one
         field_id = next_partition_field_id++;
       }
@@ -1019,7 +1019,7 @@ Status ParsePartitionSpecs(const nlohmann::json& json, int8_t format_version,
     // Create partition spec with schema validation
     ICEBERG_ASSIGN_OR_RAISE(
         auto spec,
-        PartitionSpec::Make(*current_schema, PartitionSpec::kInitialSpecId,
+        PartitionSpec::Make(*current_schema, kInitialSpecId,
                             std::move(fields), /*allow_missing_fields=*/false));
     default_spec_id = spec->spec_id();
     partition_specs.push_back(std::move(spec));

--- a/src/iceberg/json_serde.cc
+++ b/src/iceberg/json_serde.cc
@@ -599,8 +599,8 @@ Result<std::unique_ptr<PartitionField>> PartitionFieldFromJson(
   int32_t field_id;
   if (allow_field_id_missing) {
     // Partition field id in v1 is not tracked, so we use -1 to indicate that.
-    ICEBERG_ASSIGN_OR_RAISE(field_id, GetJsonValueOrDefault<int32_t>(
-                                          json, kFieldId, kInvalidFieldId));
+    ICEBERG_ASSIGN_OR_RAISE(
+        field_id, GetJsonValueOrDefault<int32_t>(json, kFieldId, kInvalidFieldId));
   } else {
     ICEBERG_ASSIGN_OR_RAISE(field_id, GetJsonValue<int32_t>(json, kFieldId));
   }
@@ -1018,9 +1018,8 @@ Status ParsePartitionSpecs(const nlohmann::json& json, int8_t format_version,
 
     // Create partition spec with schema validation
     ICEBERG_ASSIGN_OR_RAISE(
-        auto spec,
-        PartitionSpec::Make(*current_schema, kInitialSpecId,
-                            std::move(fields), /*allow_missing_fields=*/false));
+        auto spec, PartitionSpec::Make(*current_schema, kInitialSpecId, std::move(fields),
+                                       /*allow_missing_fields=*/false));
     default_spec_id = spec->spec_id();
     partition_specs.push_back(std::move(spec));
   }

--- a/src/iceberg/manifest/manifest_list.h
+++ b/src/iceberg/manifest/manifest_list.h
@@ -92,7 +92,7 @@ struct ICEBERG_EXPORT ManifestFile {
   /// Field id: 502
   /// ID of a partition spec used to write the manifest; must be listed in table metadata
   /// partition-specs
-  int32_t partition_spec_id = PartitionSpec::kInitialSpecId;
+  int32_t partition_spec_id = kInitialSpecId;
   /// Field id: 517
   /// The type of files tracked by the manifest, either data or delete files; 0 for all v1
   /// manifests

--- a/src/iceberg/partition_spec.cc
+++ b/src/iceberg/partition_spec.cc
@@ -275,7 +275,7 @@ Result<std::unique_ptr<PartitionSpec>> PartitionSpec::Make(
 
 bool PartitionSpec::HasSequentialFieldIds(const PartitionSpec& spec) {
   for (size_t i = 0; i < spec.fields().size(); i += 1) {
-    if (spec.fields()[i].field_id() != PartitionSpec::kLegacyPartitionDataIdStart + i) {
+    if (spec.fields()[i].field_id() != kLegacyPartitionDataIdStart + i) {
       return false;
     }
   }

--- a/src/iceberg/partition_spec.h
+++ b/src/iceberg/partition_spec.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "iceberg/constants.h"
 #include "iceberg/iceberg_export.h"
 #include "iceberg/partition_field.h"
 #include "iceberg/result.h"
@@ -46,12 +47,6 @@ namespace iceberg {
 /// evolution.
 class ICEBERG_EXPORT PartitionSpec : public util::Formattable {
  public:
-  static constexpr int32_t kInitialSpecId = 0;
-  /// \brief The start ID for partition field.  It is only used to generate
-  /// partition field id for v1 metadata where it is tracked.
-  static constexpr int32_t kLegacyPartitionDataIdStart = 1000;
-  static constexpr int32_t kInvalidPartitionFieldId = -1;
-
   /// \brief Get an unsorted partition spec singleton.
   static const std::shared_ptr<PartitionSpec>& Unpartitioned();
 

--- a/src/iceberg/schema.cc
+++ b/src/iceberg/schema.cc
@@ -363,7 +363,7 @@ Result<int32_t> SchemaCache::InitHighestFieldId(const Schema* schema) {
   ICEBERG_ASSIGN_OR_RAISE(auto id_to_field, InitIdToFieldMap(schema));
 
   if (id_to_field.empty()) {
-    return Schema::kInitialColumnId;
+    return kInitialColumnId;
   }
 
   auto max_it = std::ranges::max_element(

--- a/src/iceberg/schema.h
+++ b/src/iceberg/schema.h
@@ -30,6 +30,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "iceberg/constants.h"
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
 #include "iceberg/schema_field.h"
@@ -48,10 +49,6 @@ class SchemaCache;
 /// evolution.
 class ICEBERG_EXPORT Schema : public StructType {
  public:
-  static constexpr int32_t kInitialSchemaId = 0;
-  static constexpr int32_t kInitialColumnId = 0;
-  static constexpr int32_t kInvalidColumnId = -1;
-
   /// \brief Special value to select all columns from manifest files.
   static constexpr std::string_view kAllColumns = "*";
 

--- a/src/iceberg/schema_field.h
+++ b/src/iceberg/schema_field.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <string_view>
 
+#include "iceberg/constants.h"
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
@@ -38,8 +39,6 @@ namespace iceberg {
 /// \brief A type combined with a name.
 class ICEBERG_EXPORT SchemaField : public iceberg::util::Formattable {
  public:
-  static constexpr int32_t kInvalidFieldId = -1;
-
   /// \brief Construct a field.
   /// \param[in] field_id The field ID.
   /// \param[in] name The field name.

--- a/src/iceberg/schema_internal.cc
+++ b/src/iceberg/schema_internal.cc
@@ -310,7 +310,7 @@ std::unique_ptr<Schema> FromStructType(StructType&& struct_type,
   for (auto& field : struct_type.fields()) {
     fields.emplace_back(std::move(field));
   }
-  auto schema_id = schema_id_opt.value_or(Schema::kInitialSchemaId);
+  auto schema_id = schema_id_opt.value_or(kInitialSchemaId);
   return std::make_unique<Schema>(std::move(fields), schema_id);
 }
 

--- a/src/iceberg/sort_order.h
+++ b/src/iceberg/sort_order.h
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "iceberg/constants.h"
 #include "iceberg/iceberg_export.h"
 #include "iceberg/sort_field.h"
 #include "iceberg/type_fwd.h"
@@ -39,9 +40,6 @@ namespace iceberg {
 /// applied to the data.
 class ICEBERG_EXPORT SortOrder : public util::Formattable {
  public:
-  static constexpr int32_t kUnsortedOrderId = 0;
-  static constexpr int32_t kInitialSortOrderId = 1;
-
   /// \brief Get an unsorted sort order singleton.
   static const std::shared_ptr<SortOrder>& Unsorted();
 

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -209,8 +209,7 @@ Result<std::unique_ptr<TableMetadata>> TableMetadata::Make(
 
   // Rebuild the partition spec using the new column ids
   ICEBERG_ASSIGN_OR_RAISE(
-      auto fresh_spec,
-      FreshPartitionSpec(kInitialSpecId, spec, schema, *fresh_schema));
+      auto fresh_spec, FreshPartitionSpec(kInitialSpecId, spec, schema, *fresh_schema));
 
   // rebuild the sort order using the new column ids
   ICEBERG_ASSIGN_OR_RAISE(

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -71,7 +71,7 @@ Result<std::unique_ptr<PartitionSpec>> FreshPartitionSpec(int32_t spec_id,
                                                           const Schema& fresh_schema) {
   std::vector<PartitionField> partition_fields;
   partition_fields.reserve(spec.fields().size());
-  int32_t last_partition_field_id = PartitionSpec::kInvalidPartitionFieldId;
+  int32_t last_partition_field_id = kInvalidPartitionFieldId;
   for (auto& field : spec.fields()) {
     ICEBERG_ASSIGN_OR_RAISE(auto source_name,
                             base_schema.FindColumnNameById(field.source_id()));
@@ -145,7 +145,7 @@ std::vector<std::unique_ptr<TableUpdate>> ChangesForCreate(
   if (auto partition_spec_result = metadata.PartitionSpec();
       partition_spec_result.has_value()) {
     auto spec = partition_spec_result.value();
-    if (spec && spec->spec_id() != PartitionSpec::kInitialSpecId) {
+    if (spec && spec->spec_id() != kInitialSpecId) {
       changes.push_back(std::make_unique<table::AddPartitionSpec>(spec));
     } else {
       changes.push_back(
@@ -205,17 +205,17 @@ Result<std::unique_ptr<TableMetadata>> TableMetadata::Make(
   int32_t last_column_id = 0;
   auto next_id = [&last_column_id]() -> int32_t { return ++last_column_id; };
   ICEBERG_ASSIGN_OR_RAISE(auto fresh_schema,
-                          AssignFreshIds(Schema::kInitialSchemaId, schema, next_id));
+                          AssignFreshIds(kInitialSchemaId, schema, next_id));
 
   // Rebuild the partition spec using the new column ids
   ICEBERG_ASSIGN_OR_RAISE(
       auto fresh_spec,
-      FreshPartitionSpec(PartitionSpec::kInitialSpecId, spec, schema, *fresh_schema));
+      FreshPartitionSpec(kInitialSpecId, spec, schema, *fresh_schema));
 
   // rebuild the sort order using the new column ids
   ICEBERG_ASSIGN_OR_RAISE(
       auto fresh_order,
-      FreshSortOrder(SortOrder::kInitialSortOrderId, sort_order, schema, *fresh_schema))
+      FreshSortOrder(kInitialSortOrderId, sort_order, schema, *fresh_schema))
 
   // Validata the metrics configuration.
   ICEBERG_RETURN_UNEXPECTED(
@@ -549,11 +549,11 @@ class TableMetadataBuilder::Impl {
     metadata_.format_version = format_version;
     metadata_.last_sequence_number = TableMetadata::kInitialSequenceNumber;
     metadata_.last_updated_ms = kInvalidLastUpdatedMs;
-    metadata_.last_column_id = Schema::kInvalidColumnId;
-    metadata_.default_spec_id = PartitionSpec::kInitialSpecId;
-    metadata_.last_partition_id = PartitionSpec::kInvalidPartitionFieldId;
+    metadata_.last_column_id = kInvalidColumnId;
+    metadata_.default_spec_id = kInitialSpecId;
+    metadata_.last_partition_id = kInvalidPartitionFieldId;
     metadata_.current_snapshot_id = kInvalidSnapshotId;
-    metadata_.default_sort_order_id = SortOrder::kInitialSortOrderId;
+    metadata_.default_sort_order_id = kInitialSortOrderId;
     metadata_.next_row_id = TableMetadata::kInitialRowId;
   }
 
@@ -1367,10 +1367,10 @@ Result<std::unique_ptr<TableMetadata>> TableMetadataBuilder::Impl::Build() {
 int32_t TableMetadataBuilder::Impl::ReuseOrCreateNewSortOrderId(
     const SortOrder& new_order) {
   if (new_order.is_unsorted()) {
-    return SortOrder::kUnsortedOrderId;
+    return kUnsortedOrderId;
   }
   // determine the next order id
-  int32_t new_order_id = SortOrder::kInitialSortOrderId;
+  int32_t new_order_id = kInitialSortOrderId;
   for (const auto& order : metadata_.sort_orders) {
     if (order->SameOrder(new_order)) {
       return order->order_id();
@@ -1384,7 +1384,7 @@ int32_t TableMetadataBuilder::Impl::ReuseOrCreateNewSortOrderId(
 int32_t TableMetadataBuilder::Impl::ReuseOrCreateNewPartitionSpecId(
     const PartitionSpec& new_spec) {
   // if the spec already exists, use the same ID. otherwise, use the highest ID + 1.
-  int32_t new_spec_id = PartitionSpec::kInitialSpecId;
+  int32_t new_spec_id = kInitialSpecId;
   for (const auto& spec : metadata_.partition_specs) {
     if (new_spec.CompatibleWith(*spec)) {
       return spec->spec_id();

--- a/src/iceberg/table_scan.cc
+++ b/src/iceberg/table_scan.cc
@@ -388,7 +388,7 @@ TableScanBuilder<ScanType>::ResolveSnapshotSchema() {
     if (context_.snapshot_id.has_value()) {
       ICEBERG_ASSIGN_OR_RAISE(auto snapshot,
                               metadata_->SnapshotById(*context_.snapshot_id));
-      int32_t schema_id = snapshot->schema_id.value_or(Schema::kInitialSchemaId);
+      int32_t schema_id = snapshot->schema_id.value_or(kInitialSchemaId);
       ICEBERG_ASSIGN_OR_RAISE(snapshot_schema_, metadata_->SchemaById(schema_id));
     } else {
       ICEBERG_ASSIGN_OR_RAISE(snapshot_schema_, metadata_->Schema());

--- a/src/iceberg/test/assign_id_visitor_test.cc
+++ b/src/iceberg/test/assign_id_visitor_test.cc
@@ -83,7 +83,7 @@ Result<std::unique_ptr<Schema>> CreateNestedSchema(
           SchemaField::MakeOptional(/*field_id=*/30, "map", CreateMapWithStructValue()),
           SchemaField::MakeRequired(/*field_id=*/40, "struct", CreateNestedStruct()),
       },
-      Schema::kInitialSchemaId, std::move(identifier_field_ids));
+      kInitialSchemaId, std::move(identifier_field_ids));
 }
 
 }  // namespace
@@ -94,7 +94,7 @@ TEST(AssignFreshIdVisitorTest, FlatSchema) {
   std::atomic<int32_t> id = 0;
   auto next_id = [&id]() { return ++id; };
   ICEBERG_UNWRAP_OR_FAIL(auto fresh_schema,
-                         AssignFreshIds(Schema::kInitialSchemaId, schema, next_id));
+                         AssignFreshIds(kInitialSchemaId, schema, next_id));
 
   ASSERT_EQ(fresh_schema->fields().size(), schema.fields().size());
   EXPECT_EQ(Schema(
@@ -104,7 +104,7 @@ TEST(AssignFreshIdVisitorTest, FlatSchema) {
                     SchemaField::MakeOptional(/*field_id=*/3, "age", iceberg::int32()),
                     SchemaField::MakeRequired(/*field_id=*/4, "data", iceberg::float64()),
                 },
-                Schema::kInitialSchemaId),
+                kInitialSchemaId),
             *fresh_schema);
 }
 
@@ -113,7 +113,7 @@ TEST(AssignFreshIdVisitorTest, NestedSchema) {
   std::atomic<int32_t> id = 0;
   auto next_id = [&id]() { return ++id; };
   ICEBERG_UNWRAP_OR_FAIL(auto fresh_schema,
-                         AssignFreshIds(Schema::kInitialSchemaId, *schema, next_id));
+                         AssignFreshIds(kInitialSchemaId, *schema, next_id));
 
   ASSERT_EQ(4, fresh_schema->fields().size());
   for (int32_t i = 0; i < fresh_schema->fields().size(); ++i) {
@@ -175,7 +175,7 @@ TEST(AssignFreshIdVisitorTest, RefreshIdentifierId) {
 
   ICEBERG_UNWRAP_OR_FAIL(auto schema, CreateNestedSchema({10, 301}));
   ICEBERG_UNWRAP_OR_FAIL(auto fresh_schema,
-                         AssignFreshIds(Schema::kInitialSchemaId, *schema, next_id));
+                         AssignFreshIds(kInitialSchemaId, *schema, next_id));
   EXPECT_THAT(fresh_schema->IdentifierFieldIds(), testing::ElementsAre(1, 12));
   ICEBERG_UNWRAP_OR_FAIL(auto identifier_field_names,
                          fresh_schema->IdentifierFieldNames());

--- a/src/iceberg/test/data_writer_test.cc
+++ b/src/iceberg/test/data_writer_test.cc
@@ -486,7 +486,7 @@ TEST_F(EqualityDeleteWriterTest, MetadataAfterClose) {
 
   // Partition spec id must be set
   ASSERT_TRUE(data_file->partition_spec_id.has_value());
-  EXPECT_EQ(data_file->partition_spec_id.value(), PartitionSpec::kInitialSpecId);
+  EXPECT_EQ(data_file->partition_spec_id.value(), kInitialSpecId);
 
   // Equality field ids must be set
   ASSERT_EQ(data_file->equality_ids.size(), 2);

--- a/src/iceberg/test/location_provider_test.cc
+++ b/src/iceberg/test/location_provider_test.cc
@@ -102,9 +102,9 @@ TEST_F(LocationProviderTest, ObjectStorageWithPartition) {
 
   ICEBERG_UNWRAP_OR_FAIL(
       auto mock_spec,
-      PartitionSpec::Make(PartitionSpec::kInitialSpecId,
+      PartitionSpec::Make(kInitialSpecId,
                           {PartitionField(1, 1, "data#1", Transform::Identity())},
-                          PartitionSpec::kInvalidPartitionFieldId + 1));
+                          kInvalidPartitionFieldId + 1));
   PartitionValues mock_partition_data({Literal::String("val#1")});
   ICEBERG_UNWRAP_OR_FAIL(
       auto location,

--- a/src/iceberg/test/manifest_evaluator_test.cc
+++ b/src/iceberg/test/manifest_evaluator_test.cc
@@ -70,7 +70,7 @@ class ManifestEvaluatorTest : public ::testing::Test {
 
   std::vector<PartitionField> BuildIdentityFields() {
     std::vector<PartitionField> fields;
-    int32_t partition_field_id = PartitionSpec::kLegacyPartitionDataIdStart;
+    int32_t partition_field_id = kLegacyPartitionDataIdStart;
     auto add_field = [&](int32_t source_id, std::string name) {
       fields.emplace_back(source_id, partition_field_id++, std::move(name),
                           Transform::Identity());

--- a/src/iceberg/test/metadata_serde_test.cc
+++ b/src/iceberg/test/metadata_serde_test.cc
@@ -114,7 +114,7 @@ TEST(MetadataSerdeTest, DeserializeV1Valid) {
       .last_updated_ms = TimePointMsFromUnixMs(1602638573874),
       .last_column_id = 3,
       .schemas = {expected_schema},
-      .current_schema_id = Schema::kInitialSchemaId,
+      .current_schema_id = kInitialSchemaId,
       .partition_specs = {expected_spec},
       .default_spec_id = 0,
       .last_partition_id = 1000,

--- a/src/iceberg/test/partition_spec_test.cc
+++ b/src/iceberg/test/partition_spec_test.cc
@@ -133,7 +133,7 @@ TEST(PartitionSpecTest, PartitionTypeTest) {
   auto field6 = SchemaField::MakeRequired(6, "id_truncate", int32());
   auto const schema = std::make_shared<Schema>(
       std::vector<SchemaField>{field1, field2, field3, field4, field5, field6},
-      Schema::kInitialSchemaId);
+      kInitialSchemaId);
 
   ICEBERG_UNWRAP_OR_FAIL(auto parsed_spec, PartitionSpecFromJson(schema, json, 1));
   ICEBERG_UNWRAP_OR_FAIL(auto partition_type, parsed_spec->PartitionType(*schema));
@@ -152,7 +152,7 @@ TEST(PartitionSpecTest, PartitionTypeTest) {
 TEST(PartitionSpecTest, InvalidTransformForType) {
   // Test Day transform on string type (should fail)
   auto field_string = SchemaField::MakeRequired(6, "s", string());
-  Schema schema_string({field_string}, Schema::kInitialSchemaId);
+  Schema schema_string({field_string}, kInitialSchemaId);
 
   PartitionField pt_field_invalid(6, 1005, "s_day", Transform::Day());
   auto result = PartitionSpec::Make(schema_string, 1, {pt_field_invalid}, false);
@@ -169,7 +169,7 @@ TEST(PartitionSpecTest, InvalidTransformForType) {
 TEST(PartitionSpecTest, SourceIdNotFound) {
   auto field1 = SchemaField::MakeRequired(1, "id", int64());
   auto field2 = SchemaField::MakeRequired(2, "ts", timestamp());
-  Schema schema({field1, field2}, Schema::kInitialSchemaId);
+  Schema schema({field1, field2}, kInitialSchemaId);
 
   // Try to create partition field with source ID 99 which doesn't exist
   PartitionField pt_field_invalid(99, 1000, "Test", Transform::Identity());
@@ -182,7 +182,7 @@ TEST(PartitionSpecTest, SourceIdNotFound) {
 TEST(PartitionSpecTest, AllowMissingFields) {
   auto field1 = SchemaField::MakeRequired(1, "id", int64());
   auto field2 = SchemaField::MakeRequired(2, "ts", timestamp());
-  Schema schema({field1, field2}, Schema::kInitialSchemaId);
+  Schema schema({field1, field2}, kInitialSchemaId);
 
   // Create partition field with source ID 99 which doesn't exist
   PartitionField pt_field_missing(99, 1000, "Test", Transform::Identity());
@@ -204,13 +204,13 @@ TEST(PartitionSpecTest, AllowMissingFields) {
 TEST(PartitionSpecTest, PartitionFieldInStruct) {
   auto field1 = SchemaField::MakeRequired(1, "id", int64());
   auto field2 = SchemaField::MakeRequired(2, "ts", timestamp());
-  Schema base_schema({field1, field2}, Schema::kInitialSchemaId);
+  Schema base_schema({field1, field2}, kInitialSchemaId);
 
   auto struct_type =
       std::make_shared<StructType>(std::vector<SchemaField>{field1, field2});
   auto outer_struct = SchemaField::MakeRequired(11, "MyStruct", struct_type);
 
-  Schema schema({outer_struct}, Schema::kInitialSchemaId);
+  Schema schema({outer_struct}, kInitialSchemaId);
   PartitionField pt_field(1, 1000, "id_partition", Transform::Identity());
 
   EXPECT_THAT(PartitionSpec::Make(schema, 1, {pt_field}, false), IsOk());
@@ -226,7 +226,7 @@ TEST(PartitionSpecTest, PartitionFieldInStructInStruct) {
   auto outer_struct = std::make_shared<StructType>(std::vector<SchemaField>{inner_field});
   SchemaField outer_field(12, "Outer", outer_struct, true);
 
-  Schema schema({outer_field}, Schema::kInitialSchemaId);
+  Schema schema({outer_field}, kInitialSchemaId);
   PartitionField pt_field(1, 1000, "id_partition", Transform::Identity());
   EXPECT_THAT(PartitionSpec::Make(schema, 1, {pt_field}, false), IsOk());
 }
@@ -234,7 +234,7 @@ TEST(PartitionSpecTest, PartitionFieldInStructInStruct) {
 TEST(PartitionSpecTest, PartitionFieldInList) {
   auto list_type = std::make_shared<ListType>(1, int32(), /*element_required=*/false);
   auto list_field = SchemaField::MakeRequired(2, "MyList", list_type);
-  Schema schema({list_field}, Schema::kInitialSchemaId);
+  Schema schema({list_field}, kInitialSchemaId);
 
   // Try to partition on the list element field (field ID 1 is the element)
   PartitionField pt_field(1, 1000, "element_partition", Transform::Identity());
@@ -251,7 +251,7 @@ TEST(PartitionSpecTest, PartitionFieldInStructInList) {
                                               /*element_required=*/false);
   auto list_field = SchemaField::MakeRequired(3, "MyList", list_type);
 
-  Schema schema({list_field}, Schema::kInitialSchemaId);
+  Schema schema({list_field}, kInitialSchemaId);
   PartitionField pt_field(1, 1000, "foo_partition", Transform::Identity());
 
   auto result = PartitionSpec::Make(schema, 1, {pt_field}, false);
@@ -265,7 +265,7 @@ TEST(PartitionSpecTest, PartitionFieldInMap) {
   auto map_type = std::make_shared<MapType>(key_field, value_field);
   auto map_field = SchemaField::MakeRequired(3, "MyMap", map_type);
 
-  Schema schema({map_field}, Schema::kInitialSchemaId);
+  Schema schema({map_field}, kInitialSchemaId);
   PartitionField pt_field_key(1, 1000, "key_partition", Transform::Identity());
 
   auto result_key = PartitionSpec::Make(schema, 1, {pt_field_key}, false);
@@ -290,7 +290,7 @@ TEST(PartitionSpecTest, PartitionFieldInStructInMap) {
   auto map_type = std::make_shared<MapType>(key_field, value_field);
   auto map_field = SchemaField::MakeRequired(5, "MyMap", map_type);
 
-  Schema schema({map_field}, Schema::kInitialSchemaId);
+  Schema schema({map_field}, kInitialSchemaId);
   PartitionField pt_field_key(1, 1000, "foo_partition", Transform::Identity());
 
   auto result_key = PartitionSpec::Make(schema, 1, {pt_field_key}, false);
@@ -308,7 +308,7 @@ TEST(PartitionSpecTest, ValidateRedundantPartitionsExactDuplicates) {
   // Create a schema with different field types
   auto ts_field = SchemaField::MakeRequired(1, "ts", timestamp());
   auto id_field = SchemaField::MakeRequired(2, "id", int64());
-  Schema schema({ts_field, id_field}, Schema::kInitialSchemaId);
+  Schema schema({ts_field, id_field}, kInitialSchemaId);
 
   // Test: exact duplicate transforms on same field (same dedup name)
   {
@@ -334,7 +334,7 @@ TEST(PartitionSpecTest, ValidateRedundantPartitionsExactDuplicates) {
   // Test: same truncate width on same field (redundant)
   {
     auto name_field = SchemaField::MakeRequired(3, "name", string());
-    Schema schema_with_string({name_field}, Schema::kInitialSchemaId);
+    Schema schema_with_string({name_field}, kInitialSchemaId);
 
     PartitionField truncate1(3, 1000, "name_trunc_4_3_1", Transform::Truncate(4));
     PartitionField truncate2(3, 1001, "name_trunc_4_3_2", Transform::Truncate(4));
@@ -351,7 +351,7 @@ TEST(PartitionSpecTest, ValidateRedundantPartitionsAllowedCases) {
   auto ts_field = SchemaField::MakeRequired(1, "ts", timestamp());
   auto id_field = SchemaField::MakeRequired(2, "id", int64());
   auto name_field = SchemaField::MakeRequired(3, "name", string());
-  Schema schema({ts_field, id_field, name_field}, Schema::kInitialSchemaId);
+  Schema schema({ts_field, id_field, name_field}, kInitialSchemaId);
 
   // Test: different bucket sizes on same field (allowed - different dedup names)
   {
@@ -404,7 +404,7 @@ TEST(PartitionSpecTest, ValidateRedundantPartitionsIdentityTransforms) {
   // Create a schema with different field types
   auto id_field = SchemaField::MakeRequired(1, "id", int64());
   auto name_field = SchemaField::MakeRequired(2, "name", string());
-  Schema schema({id_field, name_field}, Schema::kInitialSchemaId);
+  Schema schema({id_field, name_field}, kInitialSchemaId);
 
   // Test: multiple identity transforms on same field (redundant)
   {
@@ -431,7 +431,7 @@ TEST(PartitionSpecTest, PartitionPath) {
   auto id_field = SchemaField::MakeRequired(1, "id", int64());
   auto name_field = SchemaField::MakeRequired(2, "name", string());
   auto ts_field = SchemaField::MakeRequired(3, "ts", timestamp());
-  Schema schema({id_field, name_field, ts_field}, Schema::kInitialSchemaId);
+  Schema schema({id_field, name_field, ts_field}, kInitialSchemaId);
 
   // Create partition fields
   PartitionField id_field_partition(1, 1000, "id_partition", Transform::Identity());

--- a/src/iceberg/test/snapshot_util_test.cc
+++ b/src/iceberg/test/snapshot_util_test.cc
@@ -77,10 +77,10 @@ std::shared_ptr<TableMetadata> CreateTableMetadataWithSnapshots(
   metadata->last_column_id = 2;
   metadata->current_schema_id = 0;
   metadata->schemas.push_back(CreateTestSchema());
-  metadata->default_spec_id = PartitionSpec::kInitialSpecId;
+  metadata->default_spec_id = kInitialSpecId;
   metadata->last_partition_id = 0;
   metadata->current_snapshot_id = main2_snapshot_id;
-  metadata->default_sort_order_id = SortOrder::kInitialSortOrderId;
+  metadata->default_sort_order_id = kInitialSortOrderId;
   metadata->sort_orders.push_back(SortOrder::Unsorted());
   metadata->next_row_id = TableMetadata::kInitialRowId;
 

--- a/src/iceberg/test/sort_order_test.cc
+++ b/src/iceberg/test/sort_order_test.cc
@@ -197,8 +197,8 @@ TEST_F(SortOrderTest, MakeInvalidSortOrderEmptyFields) {
 }
 
 TEST_F(SortOrderTest, MakeInvalidSortOrderUnsortedId) {
-  auto sort_order = SortOrder::Make(*schema_, kUnsortedOrderId,
-                                    std::vector<SortField>{*sort_field1_});
+  auto sort_order =
+      SortOrder::Make(*schema_, kUnsortedOrderId, std::vector<SortField>{*sort_field1_});
   EXPECT_THAT(sort_order, IsError(ErrorKind::kInvalidArgument));
   EXPECT_THAT(sort_order,
               HasErrorMessage(std::format("{} is reserved for unsorted sort order",
@@ -206,8 +206,8 @@ TEST_F(SortOrderTest, MakeInvalidSortOrderUnsortedId) {
 }
 
 TEST_F(SortOrderTest, MakeValidUnsortedSortOrder) {
-  ICEBERG_UNWRAP_OR_FAIL(auto sort_order, SortOrder::Make(kUnsortedOrderId,
-                                                          std::vector<SortField>{}));
+  ICEBERG_UNWRAP_OR_FAIL(auto sort_order,
+                         SortOrder::Make(kUnsortedOrderId, std::vector<SortField>{}));
   ASSERT_NE(sort_order, nullptr);
 
   EXPECT_TRUE(sort_order->is_unsorted());

--- a/src/iceberg/test/sort_order_test.cc
+++ b/src/iceberg/test/sort_order_test.cc
@@ -197,16 +197,16 @@ TEST_F(SortOrderTest, MakeInvalidSortOrderEmptyFields) {
 }
 
 TEST_F(SortOrderTest, MakeInvalidSortOrderUnsortedId) {
-  auto sort_order = SortOrder::Make(*schema_, SortOrder::kUnsortedOrderId,
+  auto sort_order = SortOrder::Make(*schema_, kUnsortedOrderId,
                                     std::vector<SortField>{*sort_field1_});
   EXPECT_THAT(sort_order, IsError(ErrorKind::kInvalidArgument));
   EXPECT_THAT(sort_order,
               HasErrorMessage(std::format("{} is reserved for unsorted sort order",
-                                          SortOrder::kUnsortedOrderId)));
+                                          kUnsortedOrderId)));
 }
 
 TEST_F(SortOrderTest, MakeValidUnsortedSortOrder) {
-  ICEBERG_UNWRAP_OR_FAIL(auto sort_order, SortOrder::Make(SortOrder::kUnsortedOrderId,
+  ICEBERG_UNWRAP_OR_FAIL(auto sort_order, SortOrder::Make(kUnsortedOrderId,
                                                           std::vector<SortField>{}));
   ASSERT_NE(sort_order, nullptr);
 

--- a/src/iceberg/test/table_metadata_builder_test.cc
+++ b/src/iceberg/test/table_metadata_builder_test.cc
@@ -74,14 +74,14 @@ std::unique_ptr<TableMetadata> CreateBaseMetadata(
   metadata->schemas.push_back(CreateTestSchema());
   if (spec == nullptr) {
     metadata->partition_specs.push_back(PartitionSpec::Unpartitioned());
-    metadata->default_spec_id = PartitionSpec::kInitialSpecId;
+    metadata->default_spec_id = kInitialSpecId;
   } else {
     metadata->default_spec_id = spec->spec_id();
     metadata->partition_specs.push_back(std::move(spec));
   }
   metadata->last_partition_id = 0;
   metadata->current_snapshot_id = kInvalidSnapshotId;
-  metadata->default_sort_order_id = SortOrder::kUnsortedOrderId;
+  metadata->default_sort_order_id = kUnsortedOrderId;
   metadata->sort_orders.push_back(SortOrder::Unsorted());
   metadata->next_row_id = TableMetadata::kInitialRowId;
   return metadata;
@@ -118,17 +118,17 @@ TEST(TableMetadataTest, Make) {
 
   // Check partition spec
   ASSERT_EQ(1, metadata->partition_specs.size());
-  EXPECT_EQ(PartitionSpec::kInitialSpecId, metadata->partition_specs[0]->spec_id());
+  EXPECT_EQ(kInitialSpecId, metadata->partition_specs[0]->spec_id());
   auto spec_fields =
       metadata->partition_specs[0]->fields() | std::ranges::to<std::vector>();
   ASSERT_EQ(1, spec_fields.size());
-  EXPECT_EQ(PartitionSpec::kInvalidPartitionFieldId + 1, spec_fields[0].field_id());
+  EXPECT_EQ(kInvalidPartitionFieldId + 1, spec_fields[0].field_id());
   EXPECT_EQ(2, spec_fields[0].source_id());
   EXPECT_EQ("part_name", spec_fields[0].name());
 
   // Check sort order
   ASSERT_EQ(1, metadata->sort_orders.size());
-  EXPECT_EQ(SortOrder::kInitialSortOrderId, metadata->sort_orders[0]->order_id());
+  EXPECT_EQ(kInitialSortOrderId, metadata->sort_orders[0]->order_id());
   auto order_fields = metadata->sort_orders[0]->fields() | std::ranges::to<std::vector>();
   ASSERT_EQ(1, order_fields.size());
   EXPECT_EQ(3, order_fields[0].source_id());
@@ -215,8 +215,8 @@ TEST(TableMetadataBuilderTest, BuildFromEmpty) {
 
   EXPECT_EQ(metadata->format_version, 2);
   EXPECT_EQ(metadata->last_sequence_number, TableMetadata::kInitialSequenceNumber);
-  EXPECT_EQ(metadata->default_spec_id, PartitionSpec::kInitialSpecId);
-  EXPECT_EQ(metadata->default_sort_order_id, SortOrder::kUnsortedOrderId);
+  EXPECT_EQ(metadata->default_spec_id, kInitialSpecId);
+  EXPECT_EQ(metadata->default_sort_order_id, kUnsortedOrderId);
   EXPECT_EQ(metadata->current_snapshot_id, kInvalidSnapshotId);
   EXPECT_TRUE(metadata->metadata_log.empty());
 }
@@ -839,7 +839,7 @@ TEST(TableMetadataBuilderTest, SetCurrentSchemaWithPartitionSpecRebuild) {
   auto schema = CreateTestSchema();
   ICEBERG_UNWRAP_OR_FAIL(
       auto spec,
-      PartitionSpec::Make(PartitionSpec::kInitialSpecId,
+      PartitionSpec::Make(kInitialSpecId,
                           {PartitionField(1, 1000, "id_bucket", Transform::Bucket(16))},
                           1000));
   base->partition_specs.push_back(std::move(spec));
@@ -956,7 +956,7 @@ TEST(TableMetadataBuilderTest, SetCurrentSchemaRebuildsSpecsAndOrders) {
   auto schema = CreateTestSchema();
   ICEBERG_UNWRAP_OR_FAIL(
       auto spec,
-      PartitionSpec::Make(PartitionSpec::kInitialSpecId,
+      PartitionSpec::Make(kInitialSpecId,
                           {PartitionField(1, 1000, "id_bucket", Transform::Bucket(16))},
                           1000));
   base->partition_specs.push_back(std::move(spec));
@@ -1024,7 +1024,7 @@ TEST(TableMetadataBuilderTest, RemoveSchemasBasic) {
   builder->RemoveSchemas({2, 3});
   ICEBERG_UNWRAP_OR_FAIL(metadata, builder->Build());
   ASSERT_EQ(metadata->schemas.size(), 1);
-  EXPECT_EQ(metadata->schemas[0]->schema_id(), Schema::kInitialSchemaId);
+  EXPECT_EQ(metadata->schemas[0]->schema_id(), kInitialSchemaId);
 }
 
 TEST(TableMetadataBuilderTest, RemoveSchemasCannotRemoveCurrent) {
@@ -1076,7 +1076,7 @@ TEST(TableMetadataBuilderTest, RemoveSchemasNonExistent) {
   builder->RemoveSchemas({1, 999, 888});
   ICEBERG_UNWRAP_OR_FAIL(metadata, builder->Build());
   ASSERT_EQ(metadata->schemas.size(), 1);
-  EXPECT_EQ(metadata->schemas[0]->schema_id(), Schema::kInitialSchemaId);
+  EXPECT_EQ(metadata->schemas[0]->schema_id(), kInitialSchemaId);
 }
 
 TEST(TableMetadataBuilderTest, RemoveSchemasEmptySet) {

--- a/src/iceberg/test/table_requirements_test.cc
+++ b/src/iceberg/test/table_requirements_test.cc
@@ -50,11 +50,11 @@ std::unique_ptr<TableMetadata> CreateBaseMetadata(
   metadata->last_sequence_number = 0;
   metadata->last_updated_ms = TimePointMs{std::chrono::milliseconds(1000)};
   metadata->last_column_id = 0;
-  metadata->current_schema_id = Schema::kInitialSchemaId;
-  metadata->default_spec_id = PartitionSpec::kInitialSpecId;
+  metadata->current_schema_id = kInitialSchemaId;
+  metadata->default_spec_id = kInitialSpecId;
   metadata->last_partition_id = 0;
   metadata->current_snapshot_id = kInvalidSnapshotId;
-  metadata->default_sort_order_id = SortOrder::kUnsortedOrderId;
+  metadata->default_sort_order_id = kUnsortedOrderId;
   metadata->next_row_id = TableMetadata::kInitialRowId;
   return metadata;
 }
@@ -491,11 +491,11 @@ TEST(TableRequirementsTest, SetDefaultPartitionSpec) {
 
 TEST(TableRequirementsTest, SetDefaultPartitionSpecFailure) {
   auto metadata = CreateBaseMetadata();
-  metadata->default_spec_id = PartitionSpec::kInitialSpecId;
+  metadata->default_spec_id = kInitialSpecId;
 
   std::vector<std::unique_ptr<TableUpdate>> updates;
   updates.push_back(
-      std::make_unique<table::SetDefaultPartitionSpec>(PartitionSpec::kInitialSpecId));
+      std::make_unique<table::SetDefaultPartitionSpec>(kInitialSpecId));
 
   auto result = TableRequirements::ForUpdateTable(*metadata, updates);
   ASSERT_THAT(result, IsOk());
@@ -504,7 +504,7 @@ TEST(TableRequirementsTest, SetDefaultPartitionSpecFailure) {
 
   // Create updated metadata with different default_spec_id
   auto updated = CreateBaseMetadata();
-  updated->default_spec_id = PartitionSpec::kInitialSpecId + 1;
+  updated->default_spec_id = kInitialSpecId + 1;
 
   // Find and validate the AssertDefaultSpecID requirement
   for (const auto& req : requirements) {
@@ -801,11 +801,11 @@ TEST(TableRequirementsTest, SetDefaultSortOrder) {
 
 TEST(TableRequirementsTest, SetDefaultSortOrderFailure) {
   auto metadata = CreateBaseMetadata();
-  metadata->default_sort_order_id = SortOrder::kUnsortedOrderId;
+  metadata->default_sort_order_id = kUnsortedOrderId;
 
   std::vector<std::unique_ptr<TableUpdate>> updates;
   updates.push_back(
-      std::make_unique<table::SetDefaultSortOrder>(SortOrder::kUnsortedOrderId));
+      std::make_unique<table::SetDefaultSortOrder>(kUnsortedOrderId));
 
   auto result = TableRequirements::ForUpdateTable(*metadata, updates);
   ASSERT_THAT(result, IsOk());
@@ -814,7 +814,7 @@ TEST(TableRequirementsTest, SetDefaultSortOrderFailure) {
 
   // Create updated metadata with different default_sort_order_id
   auto updated = CreateBaseMetadata();
-  updated->default_sort_order_id = SortOrder::kUnsortedOrderId + 1;
+  updated->default_sort_order_id = kUnsortedOrderId + 1;
 
   // Find and validate the AssertDefaultSortOrderID requirement
   for (const auto& req : requirements) {

--- a/src/iceberg/test/table_requirements_test.cc
+++ b/src/iceberg/test/table_requirements_test.cc
@@ -494,8 +494,7 @@ TEST(TableRequirementsTest, SetDefaultPartitionSpecFailure) {
   metadata->default_spec_id = kInitialSpecId;
 
   std::vector<std::unique_ptr<TableUpdate>> updates;
-  updates.push_back(
-      std::make_unique<table::SetDefaultPartitionSpec>(kInitialSpecId));
+  updates.push_back(std::make_unique<table::SetDefaultPartitionSpec>(kInitialSpecId));
 
   auto result = TableRequirements::ForUpdateTable(*metadata, updates);
   ASSERT_THAT(result, IsOk());
@@ -804,8 +803,7 @@ TEST(TableRequirementsTest, SetDefaultSortOrderFailure) {
   metadata->default_sort_order_id = kUnsortedOrderId;
 
   std::vector<std::unique_ptr<TableUpdate>> updates;
-  updates.push_back(
-      std::make_unique<table::SetDefaultSortOrder>(kUnsortedOrderId));
+  updates.push_back(std::make_unique<table::SetDefaultSortOrder>(kUnsortedOrderId));
 
   auto result = TableRequirements::ForUpdateTable(*metadata, updates);
   ASSERT_THAT(result, IsOk());

--- a/src/iceberg/test/table_update_test.cc
+++ b/src/iceberg/test/table_update_test.cc
@@ -73,11 +73,11 @@ std::unique_ptr<TableMetadata> CreateBaseMetadata() {
   metadata->current_schema_id = 0;
   metadata->schemas.push_back(CreateTestSchema());
   metadata->partition_specs.push_back(PartitionSpec::Unpartitioned());
-  metadata->default_spec_id = PartitionSpec::kInitialSpecId;
+  metadata->default_spec_id = kInitialSpecId;
   metadata->last_partition_id = 0;
   metadata->current_snapshot_id = kInvalidSnapshotId;
   metadata->sort_orders.push_back(SortOrder::Unsorted());
-  metadata->default_sort_order_id = SortOrder::kUnsortedOrderId;
+  metadata->default_sort_order_id = kUnsortedOrderId;
   metadata->next_row_id = TableMetadata::kInitialRowId;
   return metadata;
 }

--- a/src/iceberg/test/update_partition_spec_test.cc
+++ b/src/iceberg/test/update_partition_spec_test.cc
@@ -63,12 +63,12 @@ class UpdatePartitionSpecTest : public ::testing::TestWithParam<int8_t> {
     // Create unpartitioned and partitioned specs matching Java test
     ICEBERG_UNWRAP_OR_FAIL(
         auto unpartitioned_spec,
-        PartitionSpec::Make(PartitionSpec::kInitialSpecId, std::vector<PartitionField>{},
-                            PartitionSpec::kLegacyPartitionDataIdStart - 1));
+        PartitionSpec::Make(kInitialSpecId, std::vector<PartitionField>{},
+                            kLegacyPartitionDataIdStart - 1));
     ICEBERG_UNWRAP_OR_FAIL(
         partitioned_spec_,
         PartitionSpec::Make(
-            PartitionSpec::kInitialSpecId,
+            kInitialSpecId,
             std::vector<PartitionField>{
                 PartitionField(3, 1000, "category", Transform::Identity()),
                 PartitionField(2, 1001, "ts_day", Transform::Day()),
@@ -131,7 +131,7 @@ class UpdatePartitionSpecTest : public ::testing::TestWithParam<int8_t> {
     metadata->default_spec_id = spec->spec_id();
     metadata->last_partition_id = spec->last_assigned_field_id();
     metadata->current_snapshot_id = kInvalidSnapshotId;
-    metadata->default_sort_order_id = SortOrder::kUnsortedOrderId;
+    metadata->default_sort_order_id = kUnsortedOrderId;
     metadata->sort_orders.push_back(SortOrder::Unsorted());
     metadata->next_row_id = TableMetadata::kInitialRowId;
     metadata->partition_specs.push_back(std::move(spec));
@@ -160,7 +160,7 @@ class UpdatePartitionSpecTest : public ::testing::TestWithParam<int8_t> {
   // Helper to create an expected partition spec
   std::shared_ptr<PartitionSpec> MakeExpectedSpec(
       const std::vector<PartitionField>& fields, int32_t last_assigned_field_id) {
-    auto spec_result = PartitionSpec::Make(PartitionSpec::kInitialSpecId, fields,
+    auto spec_result = PartitionSpec::Make(kInitialSpecId, fields,
                                            last_assigned_field_id);
     if (!spec_result.has_value()) {
       ADD_FAILURE() << "Failed to create expected spec: " << spec_result.error().message;
@@ -535,7 +535,7 @@ TEST_P(UpdatePartitionSpecTest, TestAddDeletedName) {
     ICEBERG_UNWRAP_OR_FAIL(
         auto expected_spec,
         PartitionSpec::Make(
-            PartitionSpec::kInitialSpecId,
+            kInitialSpecId,
             std::vector<PartitionField>{
                 PartitionField(3, 1000, "category", Transform::Identity()),
                 PartitionField(2, 1001, "ts_day", Transform::Day()),
@@ -547,7 +547,7 @@ TEST_P(UpdatePartitionSpecTest, TestAddDeletedName) {
     ICEBERG_UNWRAP_OR_FAIL(
         auto expected_spec,
         PartitionSpec::Make(
-            PartitionSpec::kInitialSpecId,
+            kInitialSpecId,
             std::vector<PartitionField>{
                 PartitionField(3, 1000, "category", Transform::Identity()),
                 PartitionField(2, 1001, "ts_day", Transform::Day())},
@@ -757,7 +757,7 @@ TEST_P(UpdatePartitionSpecTest, TestRemoveAndAddMultiTimes) {
   } else {
     ICEBERG_UNWRAP_OR_FAIL(
         auto expected_spec,
-        PartitionSpec::Make(PartitionSpec::kInitialSpecId,
+        PartitionSpec::Make(kInitialSpecId,
                             std::vector<PartitionField>{
                                 PartitionField(2, 1000, "ts_date", Transform::Day()),
                                 PartitionField(2, 1001, "__ts_date", Transform::Month())},

--- a/src/iceberg/test/update_partition_spec_test.cc
+++ b/src/iceberg/test/update_partition_spec_test.cc
@@ -160,8 +160,8 @@ class UpdatePartitionSpecTest : public ::testing::TestWithParam<int8_t> {
   // Helper to create an expected partition spec
   std::shared_ptr<PartitionSpec> MakeExpectedSpec(
       const std::vector<PartitionField>& fields, int32_t last_assigned_field_id) {
-    auto spec_result = PartitionSpec::Make(kInitialSpecId, fields,
-                                           last_assigned_field_id);
+    auto spec_result =
+        PartitionSpec::Make(kInitialSpecId, fields, last_assigned_field_id);
     if (!spec_result.has_value()) {
       ADD_FAILURE() << "Failed to create expected spec: " << spec_result.error().message;
       return nullptr;

--- a/src/iceberg/update/update_partition_spec.cc
+++ b/src/iceberg/update/update_partition_spec.cc
@@ -63,7 +63,7 @@ UpdatePartitionSpec::UpdatePartitionSpec(std::shared_ptr<TransactionContext> ctx
   schema_ = std::move(schema_result.value());
 
   last_assigned_partition_id_ =
-      std::max(base().last_partition_id, PartitionSpec::kLegacyPartitionDataIdStart - 1);
+      std::max(base().last_partition_id, kLegacyPartitionDataIdStart - 1);
   name_to_field_ = IndexSpecByName(*spec_);
   transform_to_field_ = IndexSpecByTransform(*spec_);
 


### PR DESCRIPTION
Moved common constants across the project to `src/iceberg/constants.h` to address the `TODO(gangwu): move other commonly used constants here.`

This addresses `#115` constants refactor request.

---
*PR created automatically by Jules for task [6289759833596412560](https://jules.google.com/task/6289759833596412560) started by @wgtmac*